### PR TITLE
Changed response for unsupported user level assignment to use '[[service...

### DIFF
--- a/commands/assign.unsupported.user.level.json
+++ b/commands/assign.unsupported.user.level.json
@@ -1,6 +1,6 @@
 {
   "name" : "~%assign.unsupported.user.level",
-  "response" : "The user level provided is not supported because it is based on the user's status on Twitch.",
+  "response" : "The user level provided is not supported because it is based on the user's status on [[service]].",
   "execUserLevel" : "MODERATOR",
   "minArgs" : 0,
   "count" : 0,


### PR DESCRIPTION
...]]' instead of 'Twitch'.